### PR TITLE
Add aliases for lazygit, bun, netlify

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -10,6 +10,7 @@ alias gp='git pull'
 alias gm='git merge'
 alias gr='git restore'
 alias gR='git reset'
+alias gg='lazygit'
 
 # Linux Aliases
 alias cat='bat'
@@ -30,6 +31,10 @@ alias pip='pip3'
 
 # Docker Aliases
 alias dockerclear='docker ps -qa | xargs docker rm -f'
+
+# Other
+alias bd='bun dev --open'
+alias ntl='netlify'
 
 # Bun
 [ -s "/Users/christian/.bun/_bun" ] && source "/Users/christian/.bun/_bun"


### PR DESCRIPTION
This pull request includes updates to the `.zshrc` file, adding new aliases to improve command efficiency.

New aliases added:

* Added `alias gg='lazygit'` for easier access to the `lazygit` command.
* Added `alias bd='bun dev --open'` and `alias ntl='netlify'` for quick access to `bun` and `netlify` commands.