### PR TITLE
Remove Amazon logo from Starship prompt

### DIFF
--- a/starship.toml
+++ b/starship.toml
@@ -10,7 +10,6 @@ $golang\
 $haskell\
 $rust\
 $ruby\
-$aws\
 $docker_context\
 $jobs\
 $cmd_duration\


### PR DESCRIPTION
This pull request includes a small change to the `starship.toml` configuration file. The change removes the `$aws module, likely indicating that the AWS prompt segment is no longer needed or has been deprecated.