### PR TITLE
Add 'rmds' alias to delete .DS_Store files from home directory folders of interest

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -19,6 +19,7 @@ alias ls='ls --color=auto'
 alias ll='ls -laF'
 alias ff='fzf'
 alias mk='function _mk(){ mkdir "$1" && cd "$1"; };_mk'
+alias rmds='find ~/Desktop/ -name ".DS_Store" -type f -delete && find ~/Documents/ -name ".DS_Store" -type f -delete && find ~/Downloads/ -name ".DS_Store" -type f -delete && find ~/Movies/ -name ".DS_Store" -type f -delete && find ~/Music/ -name ".DS_Store" -type f -delete && find ~/Pictures/ -name ".DS_Store" -type f -delete && find ~/Public/ -name ".DS_Store" -type f -delete &&  find ~/dev/ -name ".DS_Store" -type f -delete'
 
 # Python Aliases
 alias python='python3'


### PR DESCRIPTION
This pull request adds a new alias to the `.zshrc` file for removing `.DS_Store` files from various directories.

* [`.zshrc`](diffhunk://#diff-4c2d312ff50ee6b26c2cb601fc96a95eceabe4b456831762e5d6caf41b900383R22): Added the `rmds` alias, which finds and deletes `.DS_Store` files from commonly used directories, including `~/Desktop/`, `~/Documents/`, `~/Downloads/`, `~/Movies/`, `~/Music/`, `~/Pictures/`, `~/Public/`, and `~/dev/`.